### PR TITLE
Modify requirements for setuptools_scm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 
 """The setup script."""
-import os
-from os.path import basename, splitext, exists
-from glob import glob
-from shutil import rmtree
-from distutils.command.clean import clean as _clean
-
 import fnmatch
-from setuptools import setup, find_packages
+import os
+from distutils.command.clean import clean as _clean
+from glob import glob
+from os.path import basename, exists, splitext
+from shutil import rmtree
+
+from setuptools import find_packages, setup
 
 try:
     from sphinx.setup_command import BuildDoc
@@ -106,7 +106,12 @@ with open("HISTORY.rst") as history_file:
 REQUIREMENTS = parse_requirements("requirements.txt")
 
 # for 'python setup.py test' to work; need pytest runner:
-SETUP_REQUIREMENTS = ["pytest-runner", "setuptools_scm>=3.2.0", "wheel"]
+SETUP_REQUIREMENTS = [
+    "pytest-runner",
+    "setuptools_scm<7.0; python_version < '3.7'",
+    "setuptools_scm; python_version >= '3.7'",
+    "wheel",
+]
 
 TEST_REQUIREMENTS = ["pytest"]
 

--- a/tests/test_etc.py
+++ b/tests/test_etc.py
@@ -1,5 +1,6 @@
 """Testing the classes/functions in in the etc module."""
 import os
+
 import pytest
 
 from fmu.config import etc
@@ -65,12 +66,12 @@ def test_timer(capsys):
     for inum in range(100000):
         inum += 1
 
-    fmux.echo("Used time was {}".format(fmux.timer(time1)))
+    fmux.echo(f"Used time was {fmux.timer(time1)}")
     captured = capsys.readouterr()
     assert "Used time was" in captured[0]
     # repeat to see on screen
     fmux.echo("")
-    fmux.warn("Used time was {}".format(fmux.timer(time1)))
+    fmux.warn(f"Used time was {fmux.timer(time1)}")
 
 
 def test_print_fmu_header():


### PR DESCRIPTION
In order to prevent a build error for python 3.6, the `setuptools_scm` version must be < 7.0