### PR TITLE
Pin wheel>=0.38.0

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,4 +11,4 @@ pytest-runner>=4.2
 pytest>=3.8
 rstcheck
 sphinx_rtd_theme>=0.4.3
-wheel>=0.29.0
+wheel>=0.38.0


### PR DESCRIPTION
Versions of wheel from 0.30.0 to <0.38.0 have a security vulnerability ranked as "high" by Snyk.