### PR TITLE
FIX: Don't sort mappings when dumping yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,4 +71,4 @@ src/fmu/config/version.py
 .idea/
 .projectile
 .vscode/
-
+.venv/

--- a/src/fmu/config/configparserfmu.py
+++ b/src/fmu/config/configparserfmu.py
@@ -83,7 +83,12 @@ class ConfigParserFMU:
 
         xfmu.echo("Output of configuration:")
         if style in ("yaml", "yml"):
-            yaml.dump(self.config, stream=sys.stdout)
+            yaml.dump(
+                self.config,
+                default_flow_style=False,
+                sort_keys=False,
+                stream=sys.stdout,
+            )
         elif style in ("json", "jason"):
             stream = json.dumps(self.config, indent=4, default=str)
             print(stream)
@@ -224,9 +229,16 @@ class ConfigParserFMU:
         newcfg = self._strip_rmsdtype()
 
         if tool is not None:
-            mystream = yaml.dump(newcfg[tool], allow_unicode=True)
+            mystream = yaml.dump(
+                newcfg[tool],
+                default_flow_style=False,
+                sort_keys=False,
+                allow_unicode=True,
+            )
         else:
-            mystream = yaml.dump(newcfg, allow_unicode=True)
+            mystream = yaml.dump(
+                newcfg, default_flow_style=False, sort_keys=False, allow_unicode=True
+            )
 
         mystream = "".join(self._get_sysinfo()) + mystream
 
@@ -428,7 +440,7 @@ class ConfigParserFMU:
 
         """
 
-        mystream = yaml.dump(self._config)
+        mystream = yaml.dump(self._config, default_flow_style=False, sort_keys=False)
         tlist = []
         tmpl = re.findall(r"<\w+>", mystream)
         for item in tmpl:

--- a/src/fmu/config/utilities.py
+++ b/src/fmu/config/utilities.py
@@ -70,8 +70,8 @@ def compare_yaml_files(file1: str, file2: str) -> bool:
     cfg1 = yaml_load(file1)
     cfg2 = yaml_load(file2)
 
-    cfg1txt = yaml.dump(cfg1)
-    cfg2txt = yaml.dump(cfg2)
+    cfg1txt = yaml.dump(cfg1, default_flow_style=False, sort_keys=False)
+    cfg2txt = yaml.dump(cfg2, default_flow_style=False, sort_keys=False)
 
     return cfg1txt == cfg2txt
 


### PR DESCRIPTION
The YAML spec says that mappings are unordered. This means mappings do not need to maintain the ordering when reading or dumping from and to file. However, maintaining ordering is a reasonable expectation for readability in some cases.

Default flow style ensures things are dumped in block style so that lists like `[1, 2, 3]` are dumped as

```yaml
- 1
- 2
- 3
```

If this is not set pyyaml chooses whatever it thinks is best, hence this setting ensures consistency.

Resolves #74