### PR TITLE
CI: Update uv lock in update github pages

### DIFF
--- a/.github/workflows/fmu-config.yml
+++ b/.github/workflows/fmu-config.yml
@@ -78,6 +78,7 @@ jobs:
         run: |
           cp -R ./build/docs/html ../html
 
+          git checkout -- uv.lock
           git config --local user.email "fmu-config-github-action"
           git config --local user.name "fmu-config-github-action"
           git fetch origin gh-pages


### PR DESCRIPTION
Resolves #105 

uv.lock is updated when there's a scheduled run, but not updated in the main branch.
https://github.com/equinor/fmu-config/blob/9e52c3dca002670050bb5f76d385679170d80396/.github/workflows/fmu-config.yml#L41-L44
solution: dont use updated uv in update github pages job or copy over the updated uv lock in update github pages job.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
